### PR TITLE
docs: fix typo in graph_constructing.ipynb

### DIFF
--- a/docs/docs/how_to/graph_constructing.ipynb
+++ b/docs/docs/how_to/graph_constructing.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "## Architecture\n",
     "\n",
-    "At a high-level, the steps of constructing a knowledge are from text are:\n",
+    "At a high-level, the steps of constructing a knowledge graph from text are:\n",
     "\n",
     "1. **Extracting structured information from text**: Model is used to extract structured graph information from text.\n",
     "2. **Storing into graph database**: Storing the extracted structured graph information into a graph database enables downstream RAG applications\n",


### PR DESCRIPTION
Changed "At a high-level, the steps of constructing a knowledge are from text are:" to "At a high-level, the steps of constructing a knowledge graph from text are:"
